### PR TITLE
Improve naming for i18n

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
   "parserOptions": { "ecmaVersion": 6 },
   "rules": {
     "eqeqeq": "off",
-    "no-unused-vars": ["error", { "varsIgnorePattern": "update\\w*Data|updateHeader|populateEnvTable|TreeNode|(?:clear|refresh|resize)FlameGraph|populateKeyArray|clearProfilingData",
+    "no-unused-vars": ["error", { "varsIgnorePattern": "update\\w*Data|updateHeader|populateEnvTable|TreeNode|(?:clear|refresh|resize)FlameGraph|populateLocalizedStrings|clearProfilingData",
                                    "argsIgnorePattern": "^_" }],
     "max-len": ["error", 120, 8, {"ignoreComments": true}],
     "comma-dangle": "off",
@@ -32,7 +32,7 @@
     "resize": false,
     "memPoolsCanvasWidth": true,
     "memPoolsGraphWidth": true,
-    "object": false,
+    "localizedStrings": false,
     "TreeNode": false,
     "clearFlameGraph": false,
     "refreshFlameGraph": false

--- a/js/cpuChart.js
+++ b/js/cpuChart.js
@@ -107,7 +107,7 @@ cpuChart.append('text')
     .attr('y', 15 - margin.top)
     .attr('dominant-baseline', 'central')
     .style('font-size', '18px')
-    .text(object.cpuTitle);
+    .text(localizedStrings.cpuTitle);
 
 // Add the placeholder text
 var cpuChartPlaceholder = cpuChart.append('text')
@@ -115,7 +115,7 @@ var cpuChartPlaceholder = cpuChart.append('text')
     .attr('y', graphHeight / 2 - 2)
     .attr('text-anchor', 'middle')
     .style('font-size', '18px')
-    .text(object.NoDataMsg);
+    .text(localizedStrings.NoDataMsg);
 
 // Add the system colour box
 cpuChart.append('rect')
@@ -131,7 +131,7 @@ var cpuSystemLabel = cpuChart.append('text')
     .attr('y', graphHeight + margin.bottom - 5)
     .attr('text-anchor', 'start')
     .attr('class', 'lineLabel')
-    .text(object.cpuSystemMsg);
+    .text(localizedStrings.cpuSystemMsg);
 
 // Add the process colour box
 cpuChart.append('rect')
@@ -146,7 +146,7 @@ cpuChart.append('text')
     .attr('x', cpuSystemLabel.node().getBBox().width + 40)
     .attr('y', graphHeight + margin.bottom - 5)
     .attr('class', 'lineLabel2')
-    .text(object.ApplicationProcessMsg);
+    .text(localizedStrings.ApplicationProcessMsg);
 
 var cpuChartIsFullScreen = false;
 

--- a/js/envTable.js
+++ b/js/envTable.js
@@ -39,7 +39,7 @@ envSVG.append('text')
     .attr('y', 15)
     .attr('dominant-baseline', 'central')
     .style('font-size', '18px')
-    .text(object.envTitle);
+    .text(localizedStrings.envTitle);
 
 var paragraph = envSVG.append('g')
     .attr('class', 'envGroup')

--- a/js/eventLoopChart.js
+++ b/js/eventLoopChart.js
@@ -126,7 +126,7 @@ elChart.append('text')
     .attr('y', 15 - margin.top)
     .attr('dominant-baseline', 'central')
     .style('font-size', '18px')
-    .text(object.eventLoopTitle);
+    .text(localizedStrings.eventLoopTitle);
 
 // Add the placeholder text
 var elChartPlaceholder = elChart.append('text')
@@ -134,7 +134,7 @@ var elChartPlaceholder = elChart.append('text')
     .attr('y', graphHeight / 2)
     .attr('text-anchor', 'middle')
     .style('font-size', '18px')
-    .text(object.NoDataMessage);
+    .text(localizedStrings.NoDataMessage);
 
 // Add the MAXIMUM colour box
 elChart.append('rect')
@@ -150,7 +150,7 @@ var elMaxLabel = elChart.append('text')
     .attr('y', graphHeight + margin.bottom - 5)
     .attr('text-anchor', 'start')
     .attr('class', 'lineLabel')
-    .text(object.eventLoopMaximumMsg);
+    .text(localizedStrings.eventLoopMaximumMsg);
 
 // Add the MINIMUM colour box
 elChart.append('rect')
@@ -165,7 +165,7 @@ var elMinLabel = elChart.append('text')
     .attr('x', elMaxLabel.node().getBBox().width + 40)
     .attr('y', graphHeight + margin.bottom - 5)
     .attr('class', 'lineLabel')
-    .text(object.eventLoopMinimumMsg);
+    .text(localizedStrings.eventLoopMinimumMsg);
 
 // Add the AVERAGE colour box
 elChart.append('rect')
@@ -180,7 +180,7 @@ elChart.append('text')
     .attr('x', elMaxLabel.node().getBBox().width + elMinLabel.node().getBBox().width + 65)
     .attr('y', graphHeight + margin.bottom - 5)
     .attr('class', 'lineLabel')
-    .text(object.eventLoopAverageMsg);
+    .text(localizedStrings.eventLoopAverageMsg);
 
 // Draw the Latest MAX Data
 elChart.append('text')

--- a/js/flamegraph.js
+++ b/js/flamegraph.js
@@ -219,7 +219,7 @@ function selectNode(node) {
 function clearSelection() {
   detailsText.selectAll('tspan').remove();
   detailsText.append('tspan')
-    .text(object.flamegraphDetailsMsg);
+    .text(localizedStrings.flamegraphDetailsMsg);
 }
 
 function clearFlameGraph() {
@@ -274,7 +274,7 @@ details.append('text')
   .attr('y', 15)
   .attr('dominant-baseline', 'central')
   .style('font-size', '18px')
-  .text(object.flamegraphCallStackTitle);
+  .text(localizedStrings.flamegraphCallStackTitle);
 
 // Add the placeholder text
 let detailsText = details.append('text')

--- a/js/gcChart.js
+++ b/js/gcChart.js
@@ -103,7 +103,7 @@ gcChart.append('text')
     .attr('y', 15 - margin.top)
     .attr('dominant-baseline', 'central')
     .style('font-size', '18px')
-    .text(object.gcTitle);
+    .text(localizedStrings.gcTitle);
 
 // Add the placeholder text
 var gcChartPlaceholder = gcChart.append('text')
@@ -111,7 +111,7 @@ var gcChartPlaceholder = gcChart.append('text')
     .attr('y', graphHeight / 2)
     .attr('text-anchor', 'middle')
     .style('font-size', '18px')
-    .text(object.NoDataMsg);
+    .text(localizedStrings.NoDataMsg);
 
 // Add the heap size colour box
 gcChart.append('rect')
@@ -127,7 +127,7 @@ var gcHeapSizeLabel = gcChart.append('text')
     .attr('y', graphHeight + margin.bottom - 5)
     .attr('text-anchor', 'start')
     .attr('class', 'lineLabel')
-    .text(object.gcHeapSizeMsg);
+    .text(localizedStrings.gcHeapSizeMsg);
 
 // Add the used heap colour box
 gcChart.append('rect')
@@ -142,7 +142,7 @@ gcChart.append('text')
     .attr('x', gcHeapSizeLabel.node().getBBox().width + 40)
     .attr('y', graphHeight + margin.bottom - 5)
     .attr('class', 'lineLabel2')
-    .text(object.gcUsedHeapMsg);
+    .text(localizedStrings.gcUsedHeapMsg);
 
 // Draw the Latest HEAP SIZE Data
 gcChart.append('text')

--- a/js/httpOutboundRequestsChart.js
+++ b/js/httpOutboundRequestsChart.js
@@ -90,7 +90,7 @@ httpOBChart.append('text')
     .attr('y', 15 - margin.top)
     .attr('dominant-baseline', 'central')
     .style('font-size', '18px')
-    .text(object.httpOutboundTitle);
+    .text(localizedStrings.httpOutboundTitle);
 
 // Add the placeholder text
 var httpOBChartPlaceholder = httpOBChart.append('text')
@@ -98,7 +98,7 @@ var httpOBChartPlaceholder = httpOBChart.append('text')
     .attr('y', tallerGraphHeight / 2)
     .attr('text-anchor', 'middle')
     .style('font-size', '18px')
-    .text(object.NoDataMsg);
+    .text(localizedStrings.NoDataMsg);
 
 function updateHttpOBData(httpOutboundRequest) {
   var httpOutboundRequestData = JSON.parse(httpOutboundRequest);  // parses the data into a JSON array

--- a/js/httpRequestsChart.js
+++ b/js/httpRequestsChart.js
@@ -86,7 +86,7 @@ httpChart.append('text')
     .attr('y', 15 - margin.top)
     .attr('dominant-baseline', 'central')
     .style('font-size', '18px')
-    .text(object.httpRequestsTitle);
+    .text(localizedStrings.httpRequestsTitle);
 
 // Add the placeholder text
 var httpChartPlaceholder = httpChart.append('text')
@@ -94,7 +94,7 @@ var httpChartPlaceholder = httpChart.append('text')
     .attr('y', tallerGraphHeight / 2)
     .attr('text-anchor', 'middle')
     .style('font-size', '18px')
-    .text(object.NoDataMsg);
+    .text(localizedStrings.NoDataMsg);
 
 function updateHttpData(httpRequest) {
   var httpRequestData = JSON.parse(httpRequest);

--- a/js/httpThroughPutChart.js
+++ b/js/httpThroughPutChart.js
@@ -98,7 +98,7 @@ httpThroughPutChart.append('text')
     .attr('y', 15 - margin.top)
     .attr('dominant-baseline', 'central')
     .style('font-size', '18px')
-    .text(object.httpThroughPutTitle);
+    .text(localizedStrings.httpThroughPutTitle);
 
 // Add the placeholder text
 var httpTPChartPlaceholder = httpThroughPutChart.append('text')
@@ -106,7 +106,7 @@ var httpTPChartPlaceholder = httpThroughPutChart.append('text')
     .attr('y', graphHeight / 2)
     .attr('text-anchor', 'middle')
     .style('font-size', '18px')
-    .text(object.NoDataMsg);
+    .text(localizedStrings.NoDataMsg);
 
 function updateThroughPutData(httpThroughPutRequestData) {
   if (httpRate.length === 1) {

--- a/js/httpTop5.js
+++ b/js/httpTop5.js
@@ -43,7 +43,7 @@ httpTop5Chart.append('text')
     .attr('y', 15 - margin.top)
     .attr('dominant-baseline', 'central')
     .style('font-size', '18px')
-    .text(object.httpTop5Title);
+    .text(localizedStrings.httpTop5Title);
 
 // Add the placeholder text
 var httpTop5ChartPlaceholder = httpTop5Chart.append('text')
@@ -51,7 +51,7 @@ var httpTop5ChartPlaceholder = httpTop5Chart.append('text')
     .attr('y', graphHeight / 2)
     .attr('text-anchor', 'middle')
     .style('font-size', '18px')
-    .text(object.NoDataMsg);
+    .text(localizedStrings.NoDataMsg);
 
 function convertURL(url, httpDiv3GraphWidth) {
   var stringToDisplay = url.toString();

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -23,7 +23,7 @@
 //   userLocale = navigator.language;
 // }
 
-function populateKeyArray(callback) {
+function populateLocalizedStrings(callback) {
   var file = new XMLHttpRequest();
   var pathToFile = '';
 
@@ -48,9 +48,9 @@ function populateKeyArray(callback) {
                         .replace('=', ':');
         let keyVal = jsonStr.split(':');
         // Define the object field (key = [0] val = [1])
-        object[keyVal[0]] = keyVal[1];
+        localizedStrings[keyVal[0]] = keyVal[1];
       }
-      callback(object);
+      callback();
     }
   };
   file.open('GET', pathToFile, false);

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -41,7 +41,7 @@ function populateLocalizedStrings(callback) {
       let lines = (file.responseText).split('\n');
       lines.pop();
       for (let i = 0; i < lines.length; i++) {
-        if(lines[i].charAt(0) !== '#') {
+        if (lines[i].charAt(0) !== '#') {
           let keyVal = lines[i]
                           .replace('\r', '')
                           .split('=');
@@ -53,6 +53,6 @@ function populateLocalizedStrings(callback) {
     }
   };
   file.open('GET', pathToFile);
-  file.overrideMimeType("text/plain; charset=utf-8");
+  file.overrideMimeType('text/plain; charset=utf-8');
   file.send();
 }

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -41,19 +41,18 @@ function populateLocalizedStrings(callback) {
       let lines = (file.responseText).split('\n');
       lines.pop();
       for (let i = 0; i < lines.length; i++) {
-        let jsonStr = lines[i]
-                        .replace('\r', '')
-                        .replace('\"', '"')
-                        .replace('\n', '')
-                        .replace('=', ':');
-        let keyVal = jsonStr.split(':');
-        // Define the object field (key = [0] val = [1])
-        localizedStrings[keyVal[0]] = keyVal[1];
+        if(lines[i].charAt(0) !== '#') {
+          let keyVal = lines[i]
+                          .replace('\r', '')
+                          .split('=');
+          // Define the object field (key = [0] val = [1])
+          localizedStrings[keyVal[0]] = keyVal[1];
+        }
       }
       callback();
     }
   };
-  file.open('GET', pathToFile, false);
-  file.setRequestHeader('Content-Type', 'text/plain');
+  file.open('GET', pathToFile);
+  file.overrideMimeType("text/plain; charset=utf-8");
   file.send();
 }

--- a/js/memChart.js
+++ b/js/memChart.js
@@ -111,7 +111,7 @@ memChart.append('text')
     .attr('y', 15 - margin.top)
     .attr('dominant-baseline', 'central')
     .style('font-size', '18px')
-    .text(object.memoryTitle);
+    .text(localizedStrings.memoryTitle);
 
 // Add the placeholder text
 var memChartPlaceholder = memChart.append('text')
@@ -119,7 +119,7 @@ var memChartPlaceholder = memChart.append('text')
     .attr('y', graphHeight / 2)
     .attr('text-anchor', 'middle')
     .style('font-size', '18px')
-    .text(object.NoDataMsg);
+    .text(localizedStrings.NoDataMsg);
 
 // Add the system colour box
 memChart.append('rect')
@@ -135,7 +135,7 @@ var memSystemLabel = memChart.append('text')
     .attr('y', graphHeight + margin.bottom - 5)
     .attr('text-anchor', 'start')
     .attr('class', 'lineLabel')
-    .text(object.SystemMsg);
+    .text(localizedStrings.SystemMsg);
 
 // Add the process colour box
 memChart.append('rect')
@@ -150,7 +150,7 @@ memChart.append('text')
     .attr('x', memSystemLabel.node().getBBox().width + 40)
     .attr('y', graphHeight + margin.bottom - 5)
     .attr('class', 'lineLabel2')
-    .text(object.ApplicationProcessMsg);
+    .text(localizedStrings.ApplicationProcessMsg);
 
 var memChartIsFullScreen = false;
 

--- a/js/probeEventsChart.js
+++ b/js/probeEventsChart.js
@@ -87,7 +87,7 @@ probesChart.append('text')
     .attr('y', 15 - margin.top)
     .attr('dominant-baseline', 'central')
     .style('font-size', '18px')
-    .text(object.probeEventsTitle);
+    .text(localizedStrings.probeEventsTitle);
 
 // Add the placeholder text
 var probesChartPlaceholder = probesChart.append('text')
@@ -95,7 +95,7 @@ var probesChartPlaceholder = probesChart.append('text')
     .attr('y', graphHeight / 2)
     .attr('text-anchor', 'middle')
     .style('font-size', '18px')
-    .text(object.NoDataMsg);
+    .text(localizedStrings.NoDataMsg);
 
 var probesChartIsFullScreen = false;
 


### PR DESCRIPTION
Calling an object 'object' is bad practice.  A lot of refactoring seems to have been done around a function that was (I assume) supposed to be called asynchronously and was actually being called synchronously (https://github.com/RuntimeTools/graphmetrics/blob/master/js/i18n.js#L56) so this PR also changes that, removes some unnecessary code and confusing naming in i18n.js and correctly sets the MIME type of the file being loaded to get rid of the XML parsing errors that are currently being emitted.