### PR TITLE
Populate translated strings synchronously

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -23,7 +23,7 @@
 //   userLocale = navigator.language;
 // }
 
-function populateLocalizedStrings(callback) {
+function populateLocalizedStrings() {
   var file = new XMLHttpRequest();
   var pathToFile = '';
 
@@ -36,23 +36,21 @@ function populateLocalizedStrings(callback) {
   //   pathToFile = 'graphmetrics/locales/FILENAME_' + userLocale + '.properties';
   // }
 
-  file.onreadystatechange = function() {
-    if (file.readyState === 4 && file.status === 200) {
-      let lines = (file.responseText).split('\n');
-      lines.pop();
-      for (let i = 0; i < lines.length; i++) {
-        if (lines[i].charAt(0) !== '#') {
-          let keyVal = lines[i]
-                          .replace('\r', '')
-                          .split('=');
-          // Define the object field (key = [0] val = [1])
-          localizedStrings[keyVal[0]] = keyVal[1];
-        }
-      }
-      callback();
-    }
-  };
-  file.open('GET', pathToFile);
+
+  file.open('GET', pathToFile, false);
   file.overrideMimeType('text/plain; charset=utf-8');
   file.send();
+  if (file.readyState === 4 && file.status === 200) {
+    let lines = (file.responseText).split('\n');
+    lines.pop();
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].charAt(0) !== '#') {
+        let keyVal = lines[i]
+                        .replace('\r', '')
+                        .split('=');
+        // Define the object field (key = [0] val = [1])
+        localizedStrings[keyVal[0]] = keyVal[1];
+      }
+    }
+  }
 }


### PR DESCRIPTION
Using ajax to load javascript scripts as per #11 has meant that when running any of our dashboards we have lost stack trace information in the developer console for errors that occur in any of the javascript files that were loaded dynamically.  Since we wait until the translated string file has been fully loaded anyway before we load any of the graphs it seems to make sense to use a synchronous call to load the strings instead, meaning that we can revert to the previous way of loading the javascript files and retain useful debug information.  This will require changes in each of the index.html files for the 3 dashboards as populateLocalizesStrings no longer takes a callback.