### PR TITLE
Fix the resize icon being 0x0 pixels in Firefox and Safari.

### DIFF
--- a/js/httpThroughPutChart.js
+++ b/js/httpThroughPutChart.js
@@ -214,7 +214,7 @@ function resizeHttpThroughputChart() {
   httpDiv2GraphWidth = httpDiv2CanvasWidth - margin.left - margin.right;
   // Redraw placeholder
   httpTPChartPlaceholder
-    .attr('x', httpGraphWidth / 2)
+    .attr('x', httpDiv2CanvasWidth / 2)
     .attr('y', tallerGraphHeight / 2);
   httpTPResize
     .attr('x', httpDiv2CanvasWidth - 30)

--- a/js/textTable.js
+++ b/js/textTable.js
@@ -51,6 +51,8 @@ function TextTable(divName, parentName, title) {
 
   // Add the maximise button
   let resizeImage = svg.append('image')
+  .attr('width', 24)
+  .attr('height', 24)
   .attr('xlink:href', 'graphmetrics/images/maximize_24_grey.png')
   .attr('class', 'maximize')
   .on('click', function(){


### PR DESCRIPTION
The resize icons on the text charts were 0x0 pixels, which displays on Chrome but not Firefox of Safari.
The no data text on the http throughput chart was also misplaced.

@robbinspg - Could you check this looks ok for you since you spotted the initial problem?