### PR TITLE
Added longest response time to HTTP summary table.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,4 +7,4 @@ Authors ordered by first contribution
  - Matt Colegate (https://github.com/mattcolegate)
  - Howard Hellyer (https://github.com/hhellyer)
  - Richard Chamberlain (https://github.com/rmchamberlain)
- 
+ - James Wallis (https://github.com/jamesemwallis)

--- a/css/style2.css
+++ b/css/style2.css
@@ -402,15 +402,18 @@
 
     .httpSummaryContent table>tr>td:first-child {
       text-align: left;
-      width: 40%;
+      width: 35%;
     }
 
     .httpSummaryContent table>tr>td:nth-child(2) {
-      width: 25%;
+      width: 17%;
     }
 
     .httpSummaryContent table>tr>td:nth-child(3) {
-      width: 35%;
+      width: 24%;
+    }
+    .httpSummaryContent table>tr>td:nth-child(4) {
+      width: 24%;
     }
 
     .httpSummaryTableHeader {

--- a/js/httpSummary.js
+++ b/js/httpSummary.js
@@ -268,6 +268,7 @@ function HttpSummary(divName, parentName, title) {
     if (e.target.tagName === 'SPAN') {
       switchCase = ($(e.target).parent().attr('id')).toString();
     }
+    console.log(switchCase);
     switch (switchCase) {
       case sort.key:
         sort.reverse = !sort.reverse;
@@ -282,6 +283,10 @@ function HttpSummary(divName, parentName, title) {
         break;
       case 'averageResponseTime':
         sort.key = 'averageResponseTime';
+        sort.reverse = false;
+        break;
+      case 'longestResponseTime':
+        sort.key = 'longestResponseTime';
         sort.reverse = false;
         break;
       default:

--- a/js/httpSummary.js
+++ b/js/httpSummary.js
@@ -268,7 +268,6 @@ function HttpSummary(divName, parentName, title) {
     if (e.target.tagName === 'SPAN') {
       switchCase = ($(e.target).parent().attr('id')).toString();
     }
-    console.log(switchCase);
     switch (switchCase) {
       case sort.key:
         sort.reverse = !sort.reverse;

--- a/js/httpSummary.js
+++ b/js/httpSummary.js
@@ -145,7 +145,9 @@ function HttpSummary(divName, parentName, title) {
   httpSummaryTableTitlesRow.append('xhtml:td').attr('class', 'httpSummaryTableHeader')
     .text('Total Hits').attr('id', 'hits').append('xhtml:span');
   httpSummaryTableTitlesRow.append('xhtml:td').attr('class', 'httpSummaryTableHeader')
-    .text('Average Response Times (ms)').attr('id', 'averageResponseTime').append('xhtml:span');
+    .text('Average Response Time (ms)').attr('id', 'averageResponseTime').append('xhtml:span');
+  httpSummaryTableTitlesRow.append('xhtml:td').attr('class', 'httpSummaryTableHeader')
+    .text('Longest Response Time (ms)').attr('id', 'longestResponseTime').append('xhtml:span');
 
   let httpSummaryContentDivHeight = tableHeight - (40 + titleBoxHeight + $('.httpSummaryTableHeaderDiv').height());
   let httpSummaryContentDiv = httpSummaryDiv.append('xhtml:div')
@@ -163,8 +165,10 @@ function HttpSummary(divName, parentName, title) {
       dummyRow.append('xhtml:td').text(httpSummaryData[i].url);
       dummyRow.append('xhtml:td').text(httpSummaryData[i].hits);
       // Round averageResponseTime to two decimal
-      let time = Number(httpSummaryData[i].averageResponseTime).toFixed(2);
-      dummyRow.append('xhtml:td').text(time);
+      let averageTime = Number(httpSummaryData[i].averageResponseTime).toFixed(2);
+      dummyRow.append('xhtml:td').text(averageTime);
+      let longestTime = Number(httpSummaryData[i].longestResponseTime).toFixed(2);
+      dummyRow.append('xhtml:td').text(longestTime);
     }
   }
 

--- a/locales/en.properties
+++ b/locales/en.properties
@@ -34,5 +34,5 @@ flamegraphDetailsTotals=Self+Children {total_percent}% (Self: {current_percent}%
 
 # Summary page
 envTitle=Environment
-httpSummaryTitle=HTTP
-summaryTitle=Summary
+httpSummaryTitle=HTTP Requests
+summaryTitle=Resource Usage

--- a/locales/en.properties
+++ b/locales/en.properties
@@ -1,5 +1,4 @@
 #titles
-envTitle=Environment
 eventLoopTitle=Event Loop Latency
 loopTitle=Loop Times
 workPoolTitle=Work Pool Items
@@ -8,7 +7,6 @@ memoryTitle=Memory
 gcTitle=Heap
 httpThroughPutTitle=HTTP Throughput
 httpOutboundTitle=HTTP Outbound Requests
-httpSummaryTitle=HTTP Summary
 httpTop5Title=Average Response Times (Top 5)
 httpRequestsTitle=HTTP Incoming Requests
 probeEventsTitle=Other Requests
@@ -33,3 +31,8 @@ flamegraphCallStackTitle=Call Stack
 flamegraphGraphTitle=Flame Graph
 flamegraphDetailsTitle=Function Details
 flamegraphDetailsTotals=Self+Children {total_percent}% (Self: {current_percent}%)
+
+# Summary page
+envTitle=Environment
+httpSummaryTitle=HTTP
+summaryTitle=Summary


### PR DESCRIPTION
Adding the longest response time to the HTTP summary table.
Longest response time was added to Javametrics in [Pull request #125](https://github.com/RuntimeTools/appmetrics-dash/pull/125).