### PR TITLE
HTTP table size & text table large value handling

### DIFF
--- a/css/style2.css
+++ b/css/style2.css
@@ -374,7 +374,7 @@
     /* Control how a Value looks if it is bigger than one line */
     foreignObject>body>div table>tr>td.largeValue {
       padding-left: 2px;
-      overflow-y: scroll;
+      overflow-y: auto;
     }
 
     foreignObject>body>div table>tr>td.largeValue>p {

--- a/css/style2.css
+++ b/css/style2.css
@@ -364,14 +364,22 @@
 
     /* Control how a Value looks if it is bigger than one line */
     foreignObject>body>div table>tr>td.largeValue {
-      padding: 5px;
-      overflow-x: scroll;
+      /*padding: 5px;*/
+      /*overflow-x: scroll;*/
     }
 
     foreignObject>body>div table>tr>td.largeValue>div {
       padding: 0;
       margin: 0;
       white-space: nowrap;
+    }
+
+    foreignObject>body>div table>tr>td.largeValue>pre {
+      border: 0;
+      background-color: inherit;
+      font-family: inherit;
+      margin: 0;
+      padding: 9.5px 2px;
     }
 
     /* Only set the width of the td when it is a text table. */

--- a/css/style2.css
+++ b/css/style2.css
@@ -110,6 +110,10 @@
         padding-bottom: 0px
     }
 
+    #flameDiv [class*="col-"] {
+      padding-right: 15px;
+    }
+
     .height-2 {
       height: 520px;
     }
@@ -369,7 +373,7 @@
 
     /* Control how a Value looks if it is bigger than one line */
     foreignObject>body>div table>tr>td.largeValue {
-      padding: 2px;
+      padding-left: 2px;
       overflow-y: scroll;
     }
 
@@ -385,7 +389,7 @@
       word-wrap: break-word;
       white-space: normal;
       display: block;
-      height: 150px;
+      line-height: 16px;
     }
 
     .envData>g>foreignObject>body>div table>tr>td {
@@ -457,13 +461,6 @@
     }
 
     .arrow {
-      /*display: inline-block;
-      vertical-align: super;
-      width: 0;
-      height: 0;
-      border-left: 5px solid transparent;
-      border-right: 5px solid transparent;
-      margin-left: 5px;*/
       border: solid black;
       border-width: 0 2px 2px 0;
       display: inline-block;

--- a/css/style2.css
+++ b/css/style2.css
@@ -360,28 +360,37 @@
     foreignObject>body>div table>tr>td {
       padding: 1px 0px;
       display: inline-block;
+      height: inherit;
+    }
+
+    foreignObject>body>div table>tr>td>p {
+      color: black;
     }
 
     /* Control how a Value looks if it is bigger than one line */
     foreignObject>body>div table>tr>td.largeValue {
-      /*padding: 5px;*/
-      /*overflow-x: scroll;*/
+      padding: 2px;
+      overflow-y: scroll;
     }
 
-    foreignObject>body>div table>tr>td.largeValue>div {
-      padding: 0;
-      margin: 0;
-      white-space: nowrap;
-    }
-
-    foreignObject>body>div table>tr>td.largeValue>pre {
+    foreignObject>body>div table>tr>td.largeValue>p {
       border: 0;
       background-color: inherit;
       font-family: inherit;
+      font-size: inherit;
+      font-weight: inherit;
       margin: 0;
-      padding: 9.5px 2px;
+      padding: 0;
+      word-break: break-all;
+      word-wrap: break-word;
+      white-space: normal;
+      display: block;
+      height: 150px;
     }
 
+    .envData>g>foreignObject>body>div table>tr>td {
+      white-space: nowrap;
+    }
     /* Only set the width of the td when it is a text table. */
     .envData>g>foreignObject>body>div table>tr>td:first-child {
       width: 40%;
@@ -393,9 +402,6 @@
 
 
     /* HTTP SUMMARY STYLES */
-
-
-
     .httpSummaryContent table>tr {
       display: list-item;
       list-style-type: none;

--- a/js/httpSummary.js
+++ b/js/httpSummary.js
@@ -36,8 +36,16 @@ function HttpSummary(divName, parentName, title) {
       // TODO - This should be dynamic, at the moment it isn't
       // as other heights are not dynamic either
       height = 510;
+    } else if ($(divName).hasClass('height-fill')) {
+      // Set height to the rest of the page
+      let body = document.getElementsByTagName('BODY')[0].offsetHeight;
+      let nav = document.getElementsByClassName('nav')[0].offsetHeight;
+      let header = document.getElementsByClassName('headerDiv')[0].offsetHeight;
+      // 20 to make it not hit the bottom
+      height = body - (nav + header) - 20;
     }
     return height;
+
   }
 
   const normalTableHeight = calculateTableHeight();
@@ -170,6 +178,24 @@ function HttpSummary(divName, parentName, title) {
       let longestTime = Number(httpSummaryData[i].longestResponseTime).toFixed(2);
       dummyRow.append('xhtml:td').text(longestTime);
     }
+    dummyData = [];
+    for (var i = 0; i < 50; i++) {
+      dummyData[i] = {};
+      dummyData[i].url = "http://localhost:" + i*100;
+      dummyData[i].hits = i;
+      dummyData[i].averageResponseTime = i*1.5;
+      dummyData[i].longestResponseTime = i*4;
+    }
+    for (var i = 0; i < dummyData.length; i++) {
+      let dummyRow = httpSummaryContentTable.append('xhtml:tr');
+      dummyRow.append('xhtml:td').text(dummyData[i].url);
+      dummyRow.append('xhtml:td').text(dummyData[i].hits);
+      // Round averageResponseTime to two decimal
+      let averageTime = Number(dummyData[i].averageResponseTime).toFixed(2);
+      dummyRow.append('xhtml:td').text(averageTime);
+      let longestTime = Number(dummyData[i].longestResponseTime).toFixed(2);
+      dummyRow.append('xhtml:td').text(longestTime);
+    }
   }
 
   function updateHttpAverages(workingData) {
@@ -215,10 +241,14 @@ function HttpSummary(divName, parentName, title) {
 
   function resizeTable() {
     if (httpSummaryIsFullScreen) {
-      tableHeight = $(divName).height() - 100;
-      if ($(divName).hasClass('height-2')) {
-        $(divName).parent().attr('style', 'position: absolute');
+      // Make sure that the height doesn't change if its already full 
+      if (!($(divName).hasClass('height-fill'))) {
+        tableHeight = $(divName).height() - 100;
+        if ($(divName).hasClass('height-2')) {
+          $(divName).parent().attr('style', 'position: absolute');
+        }
       }
+
     }
     canvasWidth = Math.max($(divName).width() - 8, 100);
     graphWidth = canvasWidth - margin.left - margin.right;

--- a/js/httpSummary.js
+++ b/js/httpSummary.js
@@ -169,32 +169,14 @@ function HttpSummary(divName, parentName, title) {
   function updateChart() {
     httpSummaryContentTable.html('');
     for (var i = 0; i < httpSummaryData.length; i++) {
-      let dummyRow = httpSummaryContentTable.append('xhtml:tr');
-      dummyRow.append('xhtml:td').text(httpSummaryData[i].url);
-      dummyRow.append('xhtml:td').text(httpSummaryData[i].hits);
+      let row = httpSummaryContentTable.append('xhtml:tr');
+      row.append('xhtml:td').text(httpSummaryData[i].url);
+      row.append('xhtml:td').text(httpSummaryData[i].hits);
       // Round averageResponseTime to two decimal
       let averageTime = Number(httpSummaryData[i].averageResponseTime).toFixed(2);
-      dummyRow.append('xhtml:td').text(averageTime);
+      row.append('xhtml:td').text(averageTime);
       let longestTime = Number(httpSummaryData[i].longestResponseTime).toFixed(2);
-      dummyRow.append('xhtml:td').text(longestTime);
-    }
-    dummyData = [];
-    for (var i = 0; i < 50; i++) {
-      dummyData[i] = {};
-      dummyData[i].url = "http://localhost:" + i*100;
-      dummyData[i].hits = i;
-      dummyData[i].averageResponseTime = i*1.5;
-      dummyData[i].longestResponseTime = i*4;
-    }
-    for (var i = 0; i < dummyData.length; i++) {
-      let dummyRow = httpSummaryContentTable.append('xhtml:tr');
-      dummyRow.append('xhtml:td').text(dummyData[i].url);
-      dummyRow.append('xhtml:td').text(dummyData[i].hits);
-      // Round averageResponseTime to two decimal
-      let averageTime = Number(dummyData[i].averageResponseTime).toFixed(2);
-      dummyRow.append('xhtml:td').text(averageTime);
-      let longestTime = Number(dummyData[i].longestResponseTime).toFixed(2);
-      dummyRow.append('xhtml:td').text(longestTime);
+      row.append('xhtml:td').text(longestTime);
     }
   }
 
@@ -241,7 +223,7 @@ function HttpSummary(divName, parentName, title) {
 
   function resizeTable() {
     if (httpSummaryIsFullScreen) {
-      // Make sure that the height doesn't change if its already full 
+      // Make sure that the height doesn't change if its already full
       if (!($(divName).hasClass('height-fill'))) {
         tableHeight = $(divName).height() - 100;
         if ($(divName).hasClass('height-2')) {

--- a/js/textTable.js
+++ b/js/textTable.js
@@ -85,9 +85,6 @@ function TextTable(divName, parentName, title) {
   .attr('height', (tableHeight - titleBoxHeight))
   .attr('x', '0')
   .attr('y', titleBoxHeight);
-  // .attr('class', 'httpSummaryContent');
-  // console.log(innerHTML);
-
   let innerDiv = innerHTML.append('xhtml:body').append('xhtml:div');
   let table = innerDiv.append('xhtml:table');
 
@@ -113,28 +110,50 @@ function TextTable(divName, parentName, title) {
       row.append('xhtml:td').text(tableData[i].Parameter);
       row.append('xhtml:td').text(tableData[i].Value);
     }
+    textOverflow();
+  }
 
+  function textOverflow() {
     // Check for any overflowing text
-    for (i = 0; i < $('.envData td').length; i++) {
-      let el = $('.envData td').get(i);
-      // Only check odd numbers in el list (The Value field)
-      // Math.ceil as sometimes they are .something off being equal
-      if ((Math.ceil(el.scrollWidth) > Math.ceil($(el).width()) && (i % 2 == 1)) && !($(el).hasClass('largeValue'))) {
-        // Text has overflowed
-        $(el).addClass('largeValue');
-        let text = $(el).text();
-        // TODO we should work this out dynamically so that we can
-        //      work out how many lines we actually need rather than defaulting to 5
-        // Get amount of elements and divide by five (5 lines to expand on to)
-        // let lineLength = Math.ceil((text.length) / 5);
-        // // Split string into 3
-        // let splitString = text.match(new RegExp('.{1,' + lineLength + '}', 'g'));
-        // let html = '';
-        // for (var j = 0; j < splitString.length; j++) {
-        //   html += '<div>' + splitString[j] + '</div>';
-        // }
-        let html = '<pre>' + text + '</pre>';
-        $(el).html(html);
+    let tableChildren = $($(table)[0]).find('td');
+    // Old way (Everything at once) $('.envData td')
+    for (i = 0; i < tableChildren.length; i++) {
+      let el = $(tableChildren).get(i);
+      // Only check odd numbers in el list (The Value field) Assume all titles are set well
+      if (i % 2 == 1) {
+        // Math.ceil as sometimes they are .something off being equal
+        if ((Math.ceil(el.scrollWidth) > Math.ceil($(el).width()) && (!($(el).hasClass('largeValue'))))) {
+          // Text has overflowed
+          $(el).addClass('largeValue');
+        }
+        else if ((Math.ceil(el.scrollWidth) < Math.ceil($(el).width()) && ($(el).hasClass('largeValue')))) {
+          $(el).removeClass('largeValue');
+        }
+        // Now fix text overflow
+        if ($(el).hasClass('largeValue')) {
+          // Get amount of space available in the div and fill rest of height
+          let containerHeight = $(el).closest('foreignObject>body>div').height();
+          let table = $(el).closest('table')[0];
+          let tableRows = $($(table).children());
+          // Get all small text boxes
+          let small = $(tableRows).not(':has(.largeValue)');
+          let smallHeightTotal = 0;
+          $(small).each(function() {
+            smallHeightTotal += $(this).height();
+          });
+          // This is how much space we have left to fill in the container
+          let totalHeightLeft = (containerHeight - smallHeightTotal);
+          // Get all large text boxes
+          let large = $(tableRows).has('.largeValue');
+          let amountOfLarge = $(large).length;
+          let height = (totalHeightLeft/amountOfLarge);
+          $(large).each(function() {
+            $(this).height(height);
+          });
+          let text = $(el).text();
+          let html = `<p data-toggle="tooltip" title="${text}">${text}</p>`;
+          $(el).html(html);
+        }
       }
     }
   }
@@ -164,6 +183,7 @@ function TextTable(divName, parentName, title) {
     innerHTML
     .attr('width', divCanvasWidth)
     .attr('height', tableHeight - titleBoxHeight);
+    textOverflow();
   }
 
   let exports = {};

--- a/js/textTable.js
+++ b/js/textTable.js
@@ -117,7 +117,7 @@ function TextTable(divName, parentName, title) {
     // Check for any overflowing text
     let tableChildren = $($(table)[0]).find('td');
     // Old way (Everything at once) $('.envData td')
-    for (i = 0; i < tableChildren.length; i++) {
+    for (var i = 0; i < tableChildren.length; i++) {
       let el = $(tableChildren).get(i);
       // Only check odd numbers in el list (The Value field) Assume all titles are set well
       if (i % 2 == 1) {
@@ -125,8 +125,7 @@ function TextTable(divName, parentName, title) {
         if ((Math.ceil(el.scrollWidth) > Math.ceil($(el).width()) && (!($(el).hasClass('largeValue'))))) {
           // Text has overflowed
           $(el).addClass('largeValue');
-        }
-        else if ((Math.ceil(el.scrollWidth) < Math.ceil($(el).width()) && ($(el).hasClass('largeValue')))) {
+        } else if ((Math.ceil(el.scrollWidth) < Math.ceil($(el).width()) && ($(el).hasClass('largeValue')))) {
           $(el).removeClass('largeValue');
         }
         // Now fix text overflow
@@ -146,7 +145,7 @@ function TextTable(divName, parentName, title) {
           // Get all large text boxes
           let large = $(tableRows).has('.largeValue');
           let amountOfLarge = $(large).length;
-          let height = (totalHeightLeft/amountOfLarge);
+          let height = (totalHeightLeft / amountOfLarge);
           $(large).each(function() {
             $(this).height(height);
           });

--- a/js/textTable.js
+++ b/js/textTable.js
@@ -125,7 +125,7 @@ function TextTable(divName, parentName, title) {
       if (i % 2 == 1) {
         let alreadyAssigned = $(el).hasClass('largeValue');
         let overflow = isGreater(el.scrollWidth, $(el).width());
-        if(el.hasAttribute('data-scrollWidth')) {
+        if (el.hasAttribute('data-scrollWidth')) {
           overflow = isGreater($(el).attr('data-scrollWidth'), $(el).width());
         }
         if (overflow && !(alreadyAssigned)) {
@@ -145,7 +145,7 @@ function TextTable(divName, parentName, title) {
    * @return true or false, the result of the calculation
    */
   function isGreater(first, second) {
-    return (Math.ceil(first) > Math.ceil(second))
+    return (Math.ceil(first) > Math.ceil(second));
   }
 
   /**

--- a/js/textTable.js
+++ b/js/textTable.js
@@ -142,8 +142,15 @@ function TextTable(divName, parentName, title) {
     let divCanvasWidth = $(divName).width() - 8; // -8 for margins and borders
     if (tableIsFullScreen) {
       tableHeight = $(divName).height() - 100;
+      // If parent is a graph-container (Used to vertically group graphs) make position absolute
+      if ($(divName).parent().hasClass('graph-container')) {
+        $(divName).parent().attr('style', 'position: absolute');
+      }
     } else {
       tableHeight = 250;
+      if ($(divName).parent().hasClass('graph-container')) {
+        $(divName).parent().attr('style', 'position: relative');
+      }
     }
     resizeImage
     .attr('x', divCanvasWidth - 30)

--- a/js/textTable.js
+++ b/js/textTable.js
@@ -119,22 +119,22 @@ function TextTable(divName, parentName, title) {
       let el = $('.envData td').get(i);
       // Only check odd numbers in el list (The Value field)
       // Math.ceil as sometimes they are .something off being equal
-      if (Math.ceil(el.scrollWidth) > Math.ceil($(el).width()) && (i % 2 == 1)) {
-        // Text has overflowed
-        $(el).addClass('largeValue');
-        let text = $(el).text();
-        // TODO we should work this out dynamically so that we can
-        //      work out how many lines we actually need rather than defaulting to 5
-        // Get amount of elements and divide by five (5 lines to expand on to)
-        let lineLength = Math.ceil((text.length) / 5);
-        // Split string into 3
-        let splitString = text.match(new RegExp('.{1,' + lineLength + '}', 'g'));
-        let html = '';
-        for (var j = 0; j < splitString.length; j++) {
-          html += '<div>' + splitString[j] + '</div>';
-        }
-        $(el).html(html);
-      }
+      // if (Math.ceil(el.scrollWidth) > Math.ceil($(el).width()) && (i % 2 == 1)) {
+      //   // Text has overflowed
+      //   $(el).addClass('largeValue');
+      //   let text = $(el).text();
+      //   // TODO we should work this out dynamically so that we can
+      //   //      work out how many lines we actually need rather than defaulting to 5
+      //   // Get amount of elements and divide by five (5 lines to expand on to)
+      //   let lineLength = Math.ceil((text.length) / 5);
+      //   // Split string into 3
+      //   let splitString = text.match(new RegExp('.{1,' + lineLength + '}', 'g'));
+      //   let html = '';
+      //   for (var j = 0; j < splitString.length; j++) {
+      //     html += '<div>' + splitString[j] + '</div>';
+      //   }
+      //   $(el).html(html);
+      // }
     }
   }
 

--- a/js/textTable.js
+++ b/js/textTable.js
@@ -119,22 +119,23 @@ function TextTable(divName, parentName, title) {
       let el = $('.envData td').get(i);
       // Only check odd numbers in el list (The Value field)
       // Math.ceil as sometimes they are .something off being equal
-      // if (Math.ceil(el.scrollWidth) > Math.ceil($(el).width()) && (i % 2 == 1)) {
-      //   // Text has overflowed
-      //   $(el).addClass('largeValue');
-      //   let text = $(el).text();
-      //   // TODO we should work this out dynamically so that we can
-      //   //      work out how many lines we actually need rather than defaulting to 5
-      //   // Get amount of elements and divide by five (5 lines to expand on to)
-      //   let lineLength = Math.ceil((text.length) / 5);
-      //   // Split string into 3
-      //   let splitString = text.match(new RegExp('.{1,' + lineLength + '}', 'g'));
-      //   let html = '';
-      //   for (var j = 0; j < splitString.length; j++) {
-      //     html += '<div>' + splitString[j] + '</div>';
-      //   }
-      //   $(el).html(html);
-      // }
+      if ((Math.ceil(el.scrollWidth) > Math.ceil($(el).width()) && (i % 2 == 1)) && !($(el).hasClass('largeValue'))) {
+        // Text has overflowed
+        $(el).addClass('largeValue');
+        let text = $(el).text();
+        // TODO we should work this out dynamically so that we can
+        //      work out how many lines we actually need rather than defaulting to 5
+        // Get amount of elements and divide by five (5 lines to expand on to)
+        // let lineLength = Math.ceil((text.length) / 5);
+        // // Split string into 3
+        // let splitString = text.match(new RegExp('.{1,' + lineLength + '}', 'g'));
+        // let html = '';
+        // for (var j = 0; j < splitString.length; j++) {
+        //   html += '<div>' + splitString[j] + '</div>';
+        // }
+        let html = '<pre>' + text + '</pre>';
+        $(el).html(html);
+      }
     }
   }
 

--- a/js/textTable.js
+++ b/js/textTable.js
@@ -125,6 +125,7 @@ function TextTable(divName, parentName, title) {
         if ((Math.ceil(el.scrollWidth) > Math.ceil($(el).width()) && (!($(el).hasClass('largeValue'))))) {
           // Text has overflowed
           $(el).addClass('largeValue');
+          $(el).
         } else if ((Math.ceil(el.scrollWidth) < Math.ceil($(el).width()) && ($(el).hasClass('largeValue')))) {
           $(el).removeClass('largeValue');
         }

--- a/js/textTable.js
+++ b/js/textTable.js
@@ -105,19 +105,11 @@ function TextTable(divName, parentName, title) {
   function tabulate(tableData) {
     // clear the table
     table.html('');
-    let dumrow = table.append('xhtml:tr');
-    dumrow.append('xhtml:td').text('Dummy data 1');
-    dumrow.append('xhtml:td').text('Curabitur aliquet quam id dui posuere blandit. Curabitur aliquet quam id dui posuere blandit. Pellentesque in ipsum id orci porta dapibus.');
     for (var i = 0; i < tableData.length; i++) {
       let row = table.append('xhtml:tr');
       row.append('xhtml:td').text(tableData[i].Parameter);
       row.append('xhtml:td').text(tableData[i].Value);
     }
-    // test data
-    dumrow = table.append('xhtml:tr');
-    dumrow.append('xhtml:td').text('Dummy data 2');
-    dumrow.append('xhtml:td').text('Quisque velit nisi, pretium ut lacinia in, elementum id enim. Donec sollicitudin molestie malesuada.');
-
     checkTextOverflow();
   }
 


### PR DESCRIPTION
### HTTP table
The HTTP table will now size itself to take up the total height of the screen. This allows the user to see as much HTTP data as possible. 

### Text table
The text table allows large values to take up the remaining space in their respective divs, allowing scrolling if the table is still not large enough to show all the text.
If more than one large value is displayed in the table then the space will be split between the two.

Tested on Chrome, Firefox and Safari.

@tobespc could you check that this displays correctly on your laptop as that was where the initial problem occured?