### PR TITLE
Fix issue where maximized table may be in the wrong place

### DIFF
--- a/js/textTable.js
+++ b/js/textTable.js
@@ -197,25 +197,28 @@ function TextTable(divName, parentName, title) {
   }
 
   function resizeTable() {
-    let divCanvasWidth = $(divName).width() - 8; // -8 for margins and borders
-    if (tableIsFullScreen) {
-      tableHeight = $(divName).height() - 100;
-      // If parent is a graph-container (Used to vertically group graphs) make position absolute
-      if ($(divName).parent().hasClass('graph-container')) {
-        $(divName).parent().attr('style', 'position: absolute');
+    if(!$(divName).hasClass('invisible')) {
+      let divCanvasWidth = $(divName).width() - 8; // -8 for margins and borders
+      if (tableIsFullScreen) {
+        console.log("fullscreen: " + title)
+        tableHeight = $(divName).height() - 100;
+        // If parent is a graph-container (Used to vertically group graphs) make position absolute
+        if ($(divName).parent().hasClass('graph-container')) {
+          $(divName).parent().attr('style', 'position: absolute');
+        }
+      } else {
+        tableHeight = 250;
+        if ($(divName).parent().hasClass('graph-container')) {
+          $(divName).parent().attr('style', 'position: relative');
+        }
       }
-    } else {
-      tableHeight = 250;
-      if ($(divName).parent().hasClass('graph-container')) {
-        $(divName).parent().attr('style', 'position: relative');
-      }
+      resizeImage.attr('x', divCanvasWidth - 30).attr('y', 4);
+      svg.attr('width', divCanvasWidth).attr('height', tableHeight);
+      titleBox.attr('width', divCanvasWidth);
+      innerHTML.attr('width', divCanvasWidth)
+        .attr('height', tableHeight - titleBoxHeight);
+      checkTextOverflow();
     }
-    resizeImage.attr('x', divCanvasWidth - 30).attr('y', 4);
-    svg.attr('width', divCanvasWidth).attr('height', tableHeight);
-    titleBox.attr('width', divCanvasWidth);
-    innerHTML.attr('width', divCanvasWidth)
-      .attr('height', tableHeight - titleBoxHeight);
-    checkTextOverflow();
   }
 
   let exports = {};

--- a/js/textTable.js
+++ b/js/textTable.js
@@ -197,10 +197,9 @@ function TextTable(divName, parentName, title) {
   }
 
   function resizeTable() {
-    if(!$(divName).hasClass('invisible')) {
+    if (!$(divName).hasClass('invisible')) {
       let divCanvasWidth = $(divName).width() - 8; // -8 for margins and borders
       if (tableIsFullScreen) {
-        console.log("fullscreen: " + title)
         tableHeight = $(divName).height() - 100;
         // If parent is a graph-container (Used to vertically group graphs) make position absolute
         if ($(divName).parent().hasClass('graph-container')) {


### PR DESCRIPTION
If two TextTables share a parent div then on resize, the second one will overwrite the position, **'style', 'position: absolute'** or **'style', 'position: relative'**. If relative comes second (i.e. the non-maximised table) then the maximizes table appears shifted to the right.  This fix stops a table doing a resize if it is currently invisible.