### PR TITLE
Open documentation in new browser tab

### DIFF
--- a/js/header.js
+++ b/js/header.js
@@ -25,6 +25,7 @@ function updateHeader(data) {
     d3.select('.rightHeader').append('a')
       .attr('class', 'docLink')
       .attr('href', titleAndDocs.docs)
+      .attr('target', '_blank')
       .text('Go To Documentation');
   }
 }


### PR DESCRIPTION
Proposing to open the documentation in a new browser tab, so it is less disruptive to the current session.  It is also more desirable for apps that embeds the appmetrics dashboard in an iframe to open the documentation in a new browser rather than within the iframe.