### PR TITLE
Added extra darkmode class, for Java usedHeapAfterGcLine

### DIFF
--- a/css/dark-diff.css
+++ b/css/dark-diff.css
@@ -75,7 +75,8 @@
   stroke: #0094E5;
 }
 
-.darkmode path.httpsline {
+.darkmode path.httpsline,
+.darkmode path.usedHeapAfterGCLine {
   stroke: #a36df5;
 }
 


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

This class was missed in the update to add a dark theme to graphmetrics, and so the line was mismatched with its colourbox. This PR updates the css .darkmode class to fix this.