### PR TITLE
Match legend and line colour for Java Heap graph

### DIFF
--- a/css/dark-diff.css
+++ b/css/dark-diff.css
@@ -96,7 +96,7 @@
 }
 
 .darkmode .colourbox4 {
-  fill: #a36df5;
+  fill: #ff7832;
 }
 
 .darkmode .modal .btn-default {

--- a/css/themes.css
+++ b/css/themes.css
@@ -213,7 +213,7 @@ g.tick line {
 }
 
 .colourbox4 {
-  fill: #dc267f;
+  fill: #ff7832;
   stroke: #dbe6e9;
   stroke-width: 1px;
 }


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>
Noticed that the line colour and legend colour didn't match in Java Metrics Heap graph:

![image](https://user-images.githubusercontent.com/15730986/71091659-6a95b680-219d-11ea-869a-abb1fc4f278b.png)


This PR brings the colours into alignment.