### PR TITLE
Update GCTime graph to plot summary data

### DIFF
--- a/js/gcTimeChart.js
+++ b/js/gcTimeChart.js
@@ -209,7 +209,7 @@ function updateGCData(gcRequest) {
   var d = gcRequestData;
   if (d != null && d.hasOwnProperty('time')) {
     d.date = new Date(+d.time);
-    d.gcTime = +d.gcTime * 100;
+    d.gcTime = +d.gcTimeSummary * 100;
   }
   gcData.push(d);
 


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

Fixes https://github.com/eclipse/codewind/issues/2056

This alters the date plotted on the GCTime graph to be summary data,