### PR TITLE
Moving gc timeSummary to gc time

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
     socket.on('gc', function(data) {
       updateGCData(data);
       let json = JSON.parse(data);
-      summary.gc.time = json.timeSummary;
+      summary.gc.time = json.time;
       summary.gc.usedHeapAfterGCMax = json.usedHeapAfterGCMax;
       updateSummaryTable();
     });


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

Part of a fix for https://github.com/eclipse/codewind/issues/2056

Can be merged without issue

This PR reflects that `gcTime` now contains the summary for the entire run.